### PR TITLE
Enzo/fix mentions

### DIFF
--- a/main.py
+++ b/main.py
@@ -199,7 +199,7 @@ class WebhookHandler(webapp2.RequestHandler):
             # so we want to replace that
             text = text.replace('@whale_hunters_bot', '')
 
-            text_kraken = re.sub('(\/btc)', '/xbt', text)
+            text_kraken = re.sub('(/btc)', '/xbt', text)
             text_kraken = re.sub('(btc$)', 'xbt', text)
             text_kraken = re.sub('(btc\s+)', 'xbt ', text)
             if text == '/start':

--- a/main.py
+++ b/main.py
@@ -194,6 +194,11 @@ class WebhookHandler(webapp2.RequestHandler):
             return
 
         if text.startswith('/'):
+
+            # telegram sometimes appends @username if the command is used from within the client
+            # so we want to replace that
+            text = text.replace('@whale_hunters_bot', '')
+
             text_kraken = re.sub('(\/btc)', '/xbt', text)
             text_kraken = re.sub('(btc$)', 'xbt', text)
             text_kraken = re.sub('(btc\s+)', 'xbt ', text)


### PR DESCRIPTION
Small changes to accommodate the occassional hickup.

The request would fail if a mention is appended to the command, so we simply remove it.

And: somehow a backslash was added in the /btc to /xbt kraken request string replacement. Fixed that.